### PR TITLE
fix: Refresh the planner before reusing it

### DIFF
--- a/execution/engine/execution_engine.go
+++ b/execution/engine/execution_engine.go
@@ -247,6 +247,8 @@ func (e *ExecutionEngine) getCachedPlan(ctx *internalExecutionContext, operation
 
 	e.plannerMu.Lock()
 	defer e.plannerMu.Unlock()
+
+	e.planner.Refresh()
 	planResult := e.planner.Plan(operation, definition, operationName, report)
 	if report.HasErrors() {
 		return nil

--- a/v2/pkg/astvisitor/visitor.go
+++ b/v2/pkg/astvisitor/visitor.go
@@ -103,6 +103,26 @@ func NewWalker(ancestorSize int) Walker {
 	}
 }
 
+func (w *Walker) Reset() {
+	w.Ancestors = w.Ancestors[:0]
+	w.Path = w.Path[:0]
+	w.EnclosingTypeDefinition = ast.Node{}
+	w.SelectionsBefore = w.SelectionsBefore[:0]
+	w.SelectionsAfter = w.SelectionsAfter[:0]
+	w.Report = nil
+	w.CurrentRef = 0
+	w.CurrentKind = 0
+	w.document = nil
+	w.definition = nil
+	w.ResetVisitors() // reset visitors and deferred
+	w.Depth = 0
+	w.TypeDefinitions = w.TypeDefinitions[:0]
+	w.stop = false
+	w.skip = false
+	w.revisit = false
+	w.filter = nil
+}
+
 type (
 	// EnterOperationDefinitionVisitor is the callback when the walker enters an operation definition
 	EnterOperationDefinitionVisitor interface {

--- a/v2/pkg/engine/plan/configuration_visitor.go
+++ b/v2/pkg/engine/plan/configuration_visitor.go
@@ -60,6 +60,50 @@ type configurationVisitor struct {
 	fieldRequirementsConfigs map[fieldIndexKey][]FederationFieldConfiguration
 }
 
+func (c *configurationVisitor) reset() {
+	c.logger = nil
+	c.debug = DebugConfiguration{}
+	c.suggestionsSelectionReasonsEnabled = false
+
+	c.operationName = ""
+	c.operation = nil
+	c.definition = nil
+	if c.walker != nil {
+		c.walker.Reset()
+	}
+
+	c.dataSources = c.dataSources[:0]
+	c.fieldConfigurations = c.fieldConfigurations[:0]
+
+	c.planners = c.planners[:0]
+
+	c.nodeSuggestions = nil
+	c.nodeSuggestionHints = c.nodeSuggestionHints[:0]
+
+	c.parentTypeNodes = c.parentTypeNodes[:0]
+	c.arrayFields = c.arrayFields[:0]
+	c.selectionSetRefs = c.selectionSetRefs[:0]
+	c.skipFieldsRefs = c.skipFieldsRefs[:0]
+	c.missingPathTracker = map[string]struct{}{}
+	c.potentiallyMissingPathTracker = map[string]struct{}{}
+	c.addedPathTracker = c.addedPathTracker[:0]
+	c.addedPathTrackerIndex = map[string][]int{}
+
+	c.pendingRequiredFields = map[int]selectionSetPendingRequirements{}
+	c.processedFieldNotHavingRequires = map[int]struct{}{}
+	c.visitedFieldsAbstractChecks = map[int]struct{}{}
+	c.fieldDependenciesForPlanners = map[int][]int{}
+	c.fieldsPlannedOn = map[int][]int{}
+	c.fieldWaitingForRequiresDependency = map[int][]int{}
+	c.fieldRequiresDependencies = map[int][]int{}
+
+	c.secondaryRun = false
+	c.fieldRef = 0
+
+	c.fieldDependsOn = map[fieldIndexKey][]int{}
+	c.fieldRequirementsConfigs = map[fieldIndexKey][]FederationFieldConfiguration{}
+}
+
 type FailedToCreatePlanningPathsError struct {
 	MissingPaths                 []string
 	HasFieldWaitingForDependency bool

--- a/v2/pkg/engine/plan/node_selection_visitor.go
+++ b/v2/pkg/engine/plan/node_selection_visitor.go
@@ -46,6 +46,41 @@ type nodeSelectionVisitor struct {
 	fieldPathCoordinates []KeyConditionCoordinate // currentFieldPathCoordinates is a stack of field path coordinates
 }
 
+func (c *nodeSelectionVisitor) reset() {
+	c.debug = DebugConfiguration{}
+
+	c.operationName = ""
+	c.operation = nil
+	c.definition = nil
+	if c.walker != nil {
+		c.walker.Reset()
+	}
+
+	c.dataSources = c.dataSources[:0]
+	c.nodeSuggestions = nil
+
+	c.selectionSetRefs = c.selectionSetRefs[:0]
+	c.skipFieldsRefs = c.skipFieldsRefs[:0]
+
+	c.pendingKeyRequirements = map[int]pendingKeyRequirements{}
+	c.pendingFieldRequirements = map[int]pendingFieldRequirements{}
+
+	c.visitedFieldsRequiresChecks = map[fieldIndexKey]struct{}{}
+	c.visitedFieldsKeyChecks = map[fieldIndexKey]struct{}{}
+	c.visitedFieldsAbstractChecks = map[int]struct{}{}
+	c.fieldDependsOn = map[fieldIndexKey][]int{}
+	c.fieldRefDependsOn = map[int][]int{}
+	c.fieldRequirementsConfigs = map[fieldIndexKey][]FederationFieldConfiguration{}
+	c.fieldLandedTo = map[int]DSHash{}
+
+	c.secondaryRun = false
+	c.hasNewFields = false
+	c.hasUnresolvedFields = false
+
+	c.fieldPathCoordinates = c.fieldPathCoordinates[:0]
+
+}
+
 func (c *nodeSelectionVisitor) shouldRevisit() bool {
 	return c.hasNewFields || c.hasUnresolvedFields
 }

--- a/v2/pkg/engine/plan/planner.go
+++ b/v2/pkg/engine/plan/planner.go
@@ -96,6 +96,35 @@ func NewPlanner(config Configuration) (*Planner, error) {
 	return p, nil
 }
 
+// Refresh resets the planner to its initial state.
+func (p *Planner) Refresh() {
+	p.configurationWalker.Reset()
+	p.configurationVisitor.reset()
+	p.nodeSelectionsWalker.Reset()
+	p.nodeSelectionsVisitor.reset()
+	p.planningWalker.Reset()
+	p.planningVisitor.reset()
+	p.prepareOperationWalker.Reset()
+
+	astnormalization.InlineFragmentAddOnType(p.prepareOperationWalker)
+
+	p.nodeSelectionsVisitor.walker = p.nodeSelectionsWalker
+	p.nodeSelectionsWalker.RegisterEnterDocumentVisitor(p.nodeSelectionsVisitor)
+	p.nodeSelectionsWalker.RegisterFieldVisitor(p.nodeSelectionsVisitor)
+	p.nodeSelectionsWalker.RegisterEnterOperationVisitor(p.nodeSelectionsVisitor)
+	p.nodeSelectionsWalker.RegisterSelectionSetVisitor(p.nodeSelectionsVisitor)
+
+	p.configurationVisitor.fieldConfigurations = p.config.Fields
+	p.configurationVisitor.walker = p.configurationWalker
+	p.configurationWalker.RegisterEnterDocumentVisitor(p.configurationVisitor)
+	p.configurationWalker.RegisterFieldVisitor(p.configurationVisitor)
+	p.configurationWalker.RegisterEnterOperationVisitor(p.configurationVisitor)
+	p.configurationWalker.RegisterSelectionSetVisitor(p.configurationVisitor)
+
+	p.planningVisitor.Walker = p.planningWalker
+	p.planningVisitor.disableResolveFieldPositions = p.config.DisableResolveFieldPositions
+}
+
 func (p *Planner) SetConfig(config Configuration) {
 	p.config = config
 }

--- a/v2/pkg/engine/plan/visitor.go
+++ b/v2/pkg/engine/plan/visitor.go
@@ -47,6 +47,28 @@ type Visitor struct {
 	indirectInterfaceFields      map[int]indirectInterfaceField
 }
 
+func (v *Visitor) reset() {
+	v.Operation = nil
+	v.Definition = nil
+	v.Walker.Reset()
+	v.Importer = astimport.Importer{}
+	v.Config = Configuration{}
+	v.plan = nil
+	v.OperationName = ""
+	v.operationDefinition = 0
+	v.objects = v.objects[:0]
+	v.currentFields = v.currentFields[:0]
+	v.currentField = nil
+	v.planners = v.planners[:0]
+	v.skipFieldsRefs = v.skipFieldsRefs[:0]
+	v.fieldConfigs = map[int]*FieldConfiguration{}
+	v.exportedVariables = map[string]struct{}{}
+	v.skipIncludeOnFragments = map[int]skipIncludeInfo{}
+	v.disableResolveFieldPositions = false
+	v.includeQueryPlans = false
+	v.indirectInterfaceFields = map[int]indirectInterfaceField{}
+}
+
 type indirectInterfaceField struct {
 	interfaceName string
 	node          ast.Node


### PR DESCRIPTION
Hello team,

I have concerns that reusing the Planner in the execution engine of wundergraph/graphql-go-tools may be causing issues. Specifically, the execution engine retains the Planner and uses it to compute plans when executing GraphQL queries. However, during plan computation, the Planner holds onto values in its internal state. As a result, when computing the next plan, the internal state of the Planner may be in an unexpected state, potentially leading to incorrect plan values.

To resolve this issue, I propose a fix that clears the internal state of the Planner before reusing it, effectively resetting it to its initial state. This ensures that each plan computation starts from a clean state and is not affected by residual data from previous computations.

A bug has been observed where, occasionally, executing GraphQL queries results in incorrect responses. It appears that this is caused by incorrect plan calculations due to the Planner's residual internal state. With this fix, the issue seems to be improved.

In cosmo, for example, the planner seems to be generated each time.

Best regards,